### PR TITLE
(bug) U4X-1005: Get Results for Selected button should only appear when toggle for synced is turned on.

### DIFF
--- a/src/referred-orders/referred-orders.component.tsx
+++ b/src/referred-orders/referred-orders.component.tsx
@@ -371,28 +371,30 @@ const ReferredOrdersList: React.FC = () => {
                   </Layer>
                 )}
 
-                <Layer
-                  style={{
-                    margin: "5px",
-                  }}
-                >
-                  {isSyncingSelectedTestOrderResults ? (
-                    <InlineLoading
-                      description={t("syncing", "Syncing...")}
-                      status="active"
-                    />
-                  ) : (
-                    <Button
-                      size="sm"
-                      className={styles.button}
-                      onClick={() =>
-                        handleSyncSelectedTestOrderResults(selectedRows)
-                      }
-                    >
-                      {t("resultsForSelected", "Get Results For Selected")}
-                    </Button>
-                  )}
-                </Layer>
+                {syncView === "SYNCED" && (
+                  <Layer
+                    style={{
+                      margin: "5px",
+                    }}
+                  >
+                    {isSyncingSelectedTestOrderResults ? (
+                      <InlineLoading
+                        description={t("syncing", "Syncing...")}
+                        status="active"
+                      />
+                    ) : (
+                      <Button
+                        size="sm"
+                        className={styles.button}
+                        onClick={() =>
+                          handleSyncSelectedTestOrderResults(selectedRows)
+                        }
+                      >
+                        {t("resultsForSelected", "Get Results For Selected")}
+                      </Button>
+                    )}
+                  </Layer>
+                )}
                 {/* all implementation */}
 
                 {syncView === "SYNCED" && (
@@ -420,26 +422,28 @@ const ReferredOrdersList: React.FC = () => {
                   </Layer>
                 )}
 
-                <Layer
-                  style={{
-                    margin: "5px",
-                  }}
-                >
-                  {isSyncingAllTestOrders ? (
-                    <InlineLoading
-                      description={t("syncing", "Syncing...")}
-                      status="active"
-                    />
-                  ) : (
-                    <Button
-                      size="sm"
-                      className={styles.button}
-                      onClick={() => handleSyncAllTestOrders()}
-                    >
-                      {t("syncAll", "Sync All Orders")}
-                    </Button>
-                  )}
-                </Layer>
+                {syncView === "NOT_SYNCED" && (
+                  <Layer
+                    style={{
+                      margin: "5px",
+                    }}
+                  >
+                    {isSyncingAllTestOrders ? (
+                      <InlineLoading
+                        description={t("syncing", "Syncing...")}
+                        status="active"
+                      />
+                    ) : (
+                      <Button
+                        size="sm"
+                        className={styles.button}
+                        onClick={() => handleSyncAllTestOrders()}
+                      >
+                        {t("syncAll", "Sync All Orders")}
+                      </Button>
+                    )}
+                  </Layer>
+                )}
 
                 <Layer style={{ margin: "5px" }}>
                   <TableToolbarSearch


### PR DESCRIPTION


## Requirements

- [ ] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
This PR makes sure the Gets Results For Selected and Get All results  buttons to appear when the toggle is synced

## Screenshots
<!-- Required if you are making UI changes. -->
https://github.com/user-attachments/assets/f730fae5-6820-4263-9455-dd8fefd4b004


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
https://metsprogramme.atlassian.net/browse/U4X-1005

## Other
<!-- Anything not covered above -->
